### PR TITLE
feat(python): enable lockfile maintenance and update-lockfile strategy for uv

### DIFF
--- a/python.json
+++ b/python.json
@@ -1,4 +1,7 @@
 {
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"],
@@ -23,6 +26,10 @@
     {
       "matchPackageNames": ["nvidia/cuda"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["uv"],
+      "rangeStrategy": "update-lockfile"
     }
   ]
 }


### PR DESCRIPTION
Even when using the >= constraint in pyproject.toml, configure Renovate to create a pull request to update lockfiles like uv.lock.

- lockFileMaintenance: Creates a pull request to periodically update lockfiles in bulk.
- Set rangeStrategy: "update-lockfile" in the uv manager to satisfy the constraint.
Create a pull request that updates only the lockfile without modifying pyproject.toml when a new version is released.