### PR TITLE
fix: move lockFileMaintenance configuration to default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,5 +10,10 @@
   ],
   "configMigration": true,
   "minimumReleaseAge": "3 days",
-  "schedule": ["* 8-17 * * 1-5"]
+  "schedule": [
+    "* 8-17 * * 1-5"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }

--- a/python.json
+++ b/python.json
@@ -1,7 +1,4 @@
 {
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"],


### PR DESCRIPTION
## Related Issue

## Changes

Since `lockFileMaintenance` is used in languages other than Python, move it to default.

## Notes