### PR TITLE
feat(go): enable go directive updates in go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides a shared Renovate configuration for our projects.
 
 - Extends recommended Renovate settings.
 - Groups multiple major releases into separate PRs.
-- Includes custom configurations for GitHub Actions, Node.js, and Python dependencies.
+- Includes custom configurations for GitHub Actions, Go, Node.js, and Python dependencies.
 - Ensures updates are at least 3 days old before PR creation.
 - Schedules Renovate to run only on weekdays (Monday to Friday) between 8:00 and 17:00 JST.
 
@@ -16,6 +16,7 @@ This repository provides a shared Renovate configuration for our projects.
 
 - **default.json**: Main configuration. Sets base rules, timezone, PR labels, minimum release age, and schedule.
 - **actions.json**: Groups updates for common GitHub Actions (artifact and pages related) into separate PRs.
+- **go.json**: Go configuration. Enables updates for the `go` directive (minimum Go version) in `go.mod` files.
 - **node.json**: Node.js configuration. Disables major updates for `@types/node` and applies ESLint rules.
 - **python.json**: Python configuration. Groups updates for tools like Ruff, Mypy, nbdev, PyTorch, and disables CUDA updates.
 

--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     ":timezone(Asia/Tokyo)",
     ":labels(dependencies)",
     "github>tpu-kanglabs/renovate-config:actions",
+    "github>tpu-kanglabs/renovate-config:go",
     "github>tpu-kanglabs/renovate-config:node",
     "github>tpu-kanglabs/renovate-config:python"
   ],

--- a/go.json
+++ b/go.json
@@ -1,0 +1,9 @@
+{
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Add go.json to enable Renovate to update the `go` directive
(minimum Go version) in go.mod files via the gomod manager.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QE9wsYDxJGLddfpE7o2WD9